### PR TITLE
BaseException copy constructor

### DIFF
--- a/pyncpp/source/cpp_api/pyncpp/error/base_exception.cpp
+++ b/pyncpp/source/cpp_api/pyncpp/error/base_exception.cpp
@@ -29,6 +29,12 @@ void BaseException::raise(const char* message)
     raiseError(PyExc_BaseException, message);
 }
 
+BaseException::BaseException(const BaseException& other) :
+    d(new BaseExceptionPrivate)
+{
+    d->message = other.d->message;
+}
+
 BaseException::BaseException(const char* message) :
     d(new BaseExceptionPrivate)
 {

--- a/pyncpp/source/cpp_api/pyncpp/error/base_exception.h
+++ b/pyncpp/source/cpp_api/pyncpp/error/base_exception.h
@@ -31,6 +31,8 @@ public:
 
     static void raise(const char* message);
 
+    BaseException(const BaseException& other);
+
     /// Temporarily creates a native Python exception and uses it to construct a
     /// C++ exception. This is intended for the wrapper code to throw exceptions
     /// as if they originated from the Python interpreter.


### PR DESCRIPTION
Avoids crash from exception instances having a `d` pointer point to freed memory (exceptions are copied when thrown).