### PR TITLE
Fix openssl issues

### DIFF
--- a/python/unix.cmake
+++ b/python/unix.cmake
@@ -26,7 +26,7 @@ endif()
 ################################################################################
 
 if(APPLE)
-    set(default_root_dir "/usr/local/opt/openssl@1.1")
+    set(default_root_dir "/usr/local/opt/openssl")
 else()
     set(default_root_dir)
 endif()


### PR DESCRIPTION
Using the unversioned directory is preferable (on macos 10.15 the versioned one is `openssl@1.1@` instead of `openssl@1.1`