### PR TITLE
Add project name to cmake message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,12 @@ if(GIT_EXECUTABLE)
 endif()
 
 if(_success)
-    message(STATUS "Version number generated from git: ${PYNCPP_VERSION_MAJOR}.${PYNCPP_VERSION_MINOR}.${PYNCPP_VERSION_PATCH}")
+    message(STATUS "pyncpp version number generated from git: ${PYNCPP_VERSION_MAJOR}.${PYNCPP_VERSION_MINOR}.${PYNCPP_VERSION_PATCH}")
 else()
     set(PYNCPP_VERSION_MAJOR 0)
     set(PYNCPP_VERSION_MINOR 0)
     set(PYNCPP_VERSION_PATCH 0)
-    message(WARNING "Cannot use git to generate a version number. Defaulting to 0.0.0")
+    message(WARNING "Cannot use git to generate a version number for pyncpp. Defaulting to 0.0.0")
 endif()
 
 ################################################################################


### PR DESCRIPTION
When compiling pyncpp from another project the line `Version number generated from git` etc. is misleading as it does not specify this relates to pyncpp and not another external project.