### PR TITLE
fix config file issues

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -3,39 +3,31 @@
 
 include(CMakePackageConfigHelpers)
 
-foreach(config ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
+set(CONFIGS ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
+set(PREFIX_DIR "${PROJECT_BINARY_DIR}")
 
-    set(CONFIG ${config})
-    set(PREFIX_DIR "${PROJECT_BINARY_DIR}/${config}")
+configure_package_config_file("${CMAKE_CURRENT_LIST_DIR}/pyncppConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfig.cmake"
+    INSTALL_PREFIX "${PREFIX_DIR}"
+    INSTALL_DESTINATION "${PREFIX_DIR}/${PYNCPP_SHARE_SUBDIR}"
+    PATH_VARS PREFIX_DIR
+    )
 
-    configure_package_config_file("${CMAKE_CURRENT_LIST_DIR}/pyncppConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfig-${config}.cmake"
-        INSTALL_PREFIX "${PREFIX_DIR}"
-        INSTALL_DESTINATION "${PREFIX_DIR}/${PYNCPP_SHARE_SUBDIR}"
-        PATH_VARS PREFIX_DIR
-        )
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/pyncppConfigVersion.cmake"
+    VERSION "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
+    COMPATIBILITY SameMinorVersion
+    )
 
-    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/pyncppConfigVersion-${config}.cmake"
-        VERSION "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
-        COMPATIBILITY SameMinorVersion
-        )
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfig.cmake"
+    DESTINATION "${PYNCPP_SHARE_SUBDIR}"
+    COMPONENT Development
+    )
 
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfig-${config}.cmake"
-        CONFIGURATIONS ${config}
-        DESTINATION "${PYNCPP_SHARE_SUBDIR}"
-        COMPONENT Development
-        RENAME "pyncppConfig.cmake"
-        )
-
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfigVersion-${config}.cmake"
-        CONFIGURATIONS ${config}
-        DESTINATION "${PYNCPP_SHARE_SUBDIR}"
-        COMPONENT Development
-        RENAME "pyncppConfigVersion.cmake"
-        )
-
-endforeach()
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/pyncppConfigVersion.cmake"
+    DESTINATION "${PYNCPP_SHARE_SUBDIR}"
+    COMPONENT Development
+    )
 
 add_custom_target(pyncpp_config ALL
     COMMAND ${CMAKE_COMMAND}

--- a/config/pyncppConfig.cmake.in
+++ b/config/pyncppConfig.cmake.in
@@ -7,7 +7,7 @@ get_property(_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFI
 
 set(_PREFIX_DIR @PACKAGE_PREFIX_DIR@)
 
-set(_CONFIG @CONFIG@)
+set(_CONFIGS @CONFIGS@)
 
 set(pyncpp_Qt5_FOUND @PYNCPP_QT5_SUPPORT@)
 
@@ -39,24 +39,9 @@ if(NOT TARGET pyncpp_python_executable)
 
     set(_include_dir)
 
-    if(WIN32)
-        if(_CONFIG STREQUAL "Debug")
-            set(_debug_suffix "_d")
-        else()
-            set(_debug_suffix "")
-        endif()
-
-        set(_exec_path "pythonw${_debug_suffix}.exe")
-        set(_lib_path "python${_version}${_debug_suffix}.dll")
-        set(_devlib_path "libs/python${_version}${_debug_suffix}.lib")
-    else()
-        set(_exec_path "bin/python${_version}")
-        set(_lib_path "lib/libpython${_version}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-    endif()
-
     set(_path_root "${_PREFIX_DIR}/${pyncpp_PYTHON_INSTALL_DESTINATION}")
 
-    if(EXISTS "${_path_root}/${_exec_path}")
+    foreach(_CONFIG ${_CONFIGS})
         if(_GENERATOR_IS_MULTI_CONFIG)
             string(TOUPPER ${_CONFIG} _CONFIG_UPPER)
             set(_property_prefix _${_CONFIG_UPPER})
@@ -64,6 +49,20 @@ if(NOT TARGET pyncpp_python_executable)
             set_property(TARGET pyncpp_python_library APPEND PROPERTY IMPORTED_CONFIGURATIONS ${_CONFIG_UPPER})
         else()
             set(_property_prefix)
+        endif()
+
+        if(WIN32)
+            if(_CONFIG STREQUAL "Debug")
+                set(_debug_suffix "_d")
+            else()
+                set(_debug_suffix "")
+            endif()
+            set(_exec_path "pythonw${_debug_suffix}.exe")
+            set(_lib_path "python${_version}${_debug_suffix}.dll")
+            set(_devlib_path "libs/python${_version}${_debug_suffix}.lib")
+        else()
+            set(_exec_path "bin/python${_version}")
+            set(_lib_path "lib/libpython${_version}${CMAKE_SHARED_LIBRARY_SUFFIX}")
         endif()
 
         set_target_properties(pyncpp_python_executable PROPERTIES
@@ -78,10 +77,13 @@ if(NOT TARGET pyncpp_python_executable)
             set_target_properties(pyncpp_python_library PROPERTIES
                 IMPORTED_IMPLIB${_property_prefix} "${_path_root}/${_devlib_path}"
                 )
-            set(_include_dir "${_path_root}/include")
-        else()
-            set(_include_dir "${_path_root}/include/python@PYNCPP_PYTHON_SHORT_VERSION@")
         endif()
+    endforeach()
+
+    if(WIN32)
+        set(_include_dir "${_path_root}/include")
+    else()
+        set(_include_dir "${_path_root}/include/python@PYNCPP_PYTHON_SHORT_VERSION@")
     endif()
 
     if(_include_dir)


### PR DESCRIPTION
(fixes https://github.com/medInria/medInria-public/issues/1270)

A separate package config file was created for each configuration. This caused an issue on multi-config generators because the one installed in the project root corresponded to the first compiled configuration, and was not compatible with other configurations. When changing configurations between debug and non debug, the compilation failed because the python library target was only configured to point to the debug version of the library (and vice-versa).

The solution is to create only one package config file that works for all configurations.